### PR TITLE
Changes after last go-live

### DIFF
--- a/pbs/prescription/admin.py
+++ b/pbs/prescription/admin.py
@@ -306,7 +306,7 @@ class PrescriptionAdmin(DetailAdmin, BaseAdmin):
             'Success Criteria', 'Success Criteria Achieved',
             'Observations Identified', 'Proposed Action',
             'Endorsement Name/s', 'Endorsement Date',
-            'Approval Name/s', 'Approval Date', 'Approved Until',
+            'Approval Name/s', 'Approval Date', 'Approved Until','Overall Rationale',
             'Non-CALM Act Tenure?','Non-CALM Act Tenure Included','Public Value in Burn','Complete Without Other Tenures?','Risks If Exclude Other Tenures'])
 
         for item in queryset:
@@ -422,9 +422,10 @@ class PrescriptionAdmin(DetailAdmin, BaseAdmin):
                 item.approval_status_modified.astimezone(
                     local_zone).strftime('%d/%m/%Y %H:%M:%S') if item.approval_status_modified else "",
                 approved_until,
+                item.rationale,
                 "Yes" if item.non_calm_tenure else ("Unknown" if item.non_calm_tenure is None else "No"),
                 item.non_calm_tenure_included,item.non_calm_tenure_value,
-                "Yes" if item.non_calm_tenure_complete else ("" if item.non_calm_tenure_complete is None else "No"),
+                ("Yes" if item.non_calm_tenure_complete == 1  else ( "No" if item.non_calm_tenure_complete == 2 else "Yes & No")) if item.non_calm_tenure else "",
                 item.non_calm_tenure_risks
             ])
 

--- a/pbs/prescription/admin.py
+++ b/pbs/prescription/admin.py
@@ -122,7 +122,8 @@ class PrescriptionAdmin(DetailAdmin, BaseAdmin):
                 ('aircraft_burn', 'remote_sensing_priority'),
                 ('priority', 'rationale'),
                 'purposes', 'treatment_percentage',
-                'area', 'perimeter')
+                'area', 'perimeter'
+            )
         }),
     )
     search_fields = ('name', 'burn_id', 'location')
@@ -305,7 +306,8 @@ class PrescriptionAdmin(DetailAdmin, BaseAdmin):
             'Success Criteria', 'Success Criteria Achieved',
             'Observations Identified', 'Proposed Action',
             'Endorsement Name/s', 'Endorsement Date',
-            'Approval Name/s', 'Approval Date', 'Approved Until'])
+            'Approval Name/s', 'Approval Date', 'Approved Until',
+            'Non-CALM Act Tenure?','Non-CALM Act Tenure Included','Public Value in Burn','Complete Without Other Tenures?','Risks If Exclude Other Tenures'])
 
         for item in queryset:
             if item.last_season is not None:
@@ -419,7 +421,11 @@ class PrescriptionAdmin(DetailAdmin, BaseAdmin):
                 approvals,
                 item.approval_status_modified.astimezone(
                     local_zone).strftime('%d/%m/%Y %H:%M:%S') if item.approval_status_modified else "",
-                approved_until
+                approved_until,
+                "Yes" if item.non_calm_tenure else ("Unknown" if item.non_calm_tenure is None else "No"),
+                item.non_calm_tenure_included,item.non_calm_tenure_value,
+                "Yes" if item.non_calm_tenure_complete else ("" if item.non_calm_tenure_complete is None else "No"),
+                item.non_calm_tenure_risks
             ])
 
         return response
@@ -469,7 +475,9 @@ class PrescriptionAdmin(DetailAdmin, BaseAdmin):
                            'aircraft_burn',
                            # TODO: PBS-1551 # 'allocation',
                            'remote_sensing_priority', 'purposes',
-                           ('area', 'perimeter', 'treatment_percentage'))
+                           ('area', 'perimeter', 'treatment_percentage'),
+                           ('non_calm_tenure','non_calm_tenure_included','non_calm_tenure_value','non_calm_tenure_complete','non_calm_tenure_risks')
+                          )
             }), ('Other Attributes', {
                 "fields": ('tenures', 'fuel_types', 'shires',
                            'bushfire_act_zone', 'prohibited_period',
@@ -581,6 +589,7 @@ class PrescriptionAdmin(DetailAdmin, BaseAdmin):
             "form": form,
             "fields": fields,
             "exclude": exclude,
+            "widgets": form._meta.widgets if hasattr(form,"_meta") and hasattr(form._meta,"widgets") else None,
             "formfield_callback": partial(self.formfield_for_dbfield,
                                           request=request),
         }

--- a/pbs/prescription/forms.py
+++ b/pbs/prescription/forms.py
@@ -128,6 +128,7 @@ class PrescriptionEditForm(PrescriptionFormBase):
         prescription = kwargs.get('instance')
 
         super(PrescriptionEditForm, self).__init__(*args, **kwargs)
+        self.fields["non_calm_tenure_complete"].choices = Prescription.NON_CALM_TENURE_COMPLETE_CHOICES
 
         if 'description' in self.fields:
             self.fields['description'].widget.attrs.update({
@@ -158,7 +159,7 @@ class PrescriptionEditForm(PrescriptionFormBase):
     class Meta:
         model = Prescription
         widgets = {
-            "non_calm_tenure_complete":forms.widgets.CheckboxInput(),
+            "non_calm_tenure_complete":forms.widgets.RadioSelect(),
             "non_calm_tenure_included":forms.widgets.Textarea(attrs={"style":"width:90%;"}),
             "non_calm_tenure_value":forms.widgets.Textarea(attrs={"style":"width:90%;"}),
             "non_calm_tenure_risks":forms.widgets.Textarea(attrs={"style":"width:90%;"})

--- a/pbs/prescription/forms.py
+++ b/pbs/prescription/forms.py
@@ -39,6 +39,46 @@ class PrescriptionFormBase(forms.ModelForm):
             #self.fields['planned_season'].widget.attrs.update({'disabled':'disabled', 'readonly':True})
             self.fields['planned_season'].widget.attrs.update({'readonly':True})
 
+    def clean_non_calm_tenure_included(self):
+        if self.cleaned_data["non_calm_tenure"]:
+            value = self.cleaned_data.get("non_calm_tenure_included")
+            if value:
+                return value
+            else:
+                raise forms.ValidationError("Required.")
+        else:
+            return None
+
+    def clean_non_calm_tenure_value(self):
+        if self.cleaned_data["non_calm_tenure"]:
+            value = self.cleaned_data.get("non_calm_tenure_value")
+            if value:
+                return value
+            else:
+                raise forms.ValidationError("Required.")
+        else:
+            return None
+
+    def clean_non_calm_tenure_complete(self):
+        if self.cleaned_data["non_calm_tenure"]:
+            value = self.cleaned_data.get("non_calm_tenure_complete")
+            if value is None:
+                raise forms.ValidationError("Required.")
+            else:
+                return value
+        else:
+            return None
+
+    def clean_non_calm_tenure_risks(self):
+        if self.cleaned_data["non_calm_tenure"]:
+            value = self.cleaned_data.get("non_calm_tenure_risks")
+            if value:
+                return value
+            else:
+                raise forms.ValidationError("Required.")
+        else:
+            return None
+
     def clean(self):
         cleaned_data = super(PrescriptionFormBase, self).clean()
 
@@ -46,7 +86,7 @@ class PrescriptionFormBase(forms.ModelForm):
         if district is not None and not district:
             self._errors["district"] = self.error_class(
                 ['This field is required.'])
-
+        
         return cleaned_data
 
 
@@ -115,8 +155,14 @@ class PrescriptionEditForm(PrescriptionFormBase):
             if 'last_year' in self.fields:
                 self.fields['last_year'].widget.attrs['readonly'] = True
 
-    class meta:
+    class Meta:
         model = Prescription
+        widgets = {
+            "non_calm_tenure_complete":forms.widgets.CheckboxInput(),
+            "non_calm_tenure_included":forms.widgets.Textarea(attrs={"style":"width:90%;"}),
+            "non_calm_tenure_value":forms.widgets.Textarea(attrs={"style":"width:90%;"}),
+            "non_calm_tenure_risks":forms.widgets.Textarea(attrs={"style":"width:90%;"})
+        }
 
 
 class PrescriptionSummaryForm(forms.ModelForm):

--- a/pbs/prescription/migrations/0028_auto__add_field_prescription_non_calm_tenure__add_field_prescription_n.py
+++ b/pbs/prescription/migrations/0028_auto__add_field_prescription_non_calm_tenure__add_field_prescription_n.py
@@ -1,0 +1,368 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Prescription.non_calm_tenure'
+        db.add_column(u'prescription_prescription', 'non_calm_tenure',
+                      self.gf('django.db.models.fields.NullBooleanField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Prescription.non_calm_tenure_included'
+        db.add_column(u'prescription_prescription', 'non_calm_tenure_included',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Prescription.non_calm_tenure_value'
+        db.add_column(u'prescription_prescription', 'non_calm_tenure_value',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Prescription.non_calm_tenure_complete'
+        db.add_column(u'prescription_prescription', 'non_calm_tenure_complete',
+                      self.gf('django.db.models.fields.NullBooleanField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Prescription.non_calm_tenure_risks'
+        db.add_column(u'prescription_prescription', 'non_calm_tenure_risks',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Prescription.non_calm_tenure'
+        db.delete_column(u'prescription_prescription', 'non_calm_tenure')
+
+        # Deleting field 'Prescription.non_calm_tenure_included'
+        db.delete_column(u'prescription_prescription', 'non_calm_tenure_included')
+
+        # Deleting field 'Prescription.non_calm_tenure_value'
+        db.delete_column(u'prescription_prescription', 'non_calm_tenure_value')
+
+        # Deleting field 'Prescription.non_calm_tenure_complete'
+        db.delete_column(u'prescription_prescription', 'non_calm_tenure_complete')
+
+        # Deleting field 'Prescription.non_calm_tenure_risks'
+        db.delete_column(u'prescription_prescription', 'non_calm_tenure_risks')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'prescription.approval': {
+            'Meta': {'ordering': "[u'-id']", 'object_name': 'Approval'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_approval_created'", 'to': u"orm['auth.User']"}),
+            'extension_count': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'initial_valid_to': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2019, 11, 1, 0, 0)'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_approval_modified'", 'to': u"orm['auth.User']"}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'}),
+            'valid_to': ('django.db.models.fields.DateField', [], {})
+        },
+        u'prescription.briefingchecklist': {
+            'Meta': {'ordering': "[u'smeac__id', u'id']", 'object_name': 'BriefingChecklist'},
+            'action': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['risk.Action']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_briefingchecklist_created'", 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_briefingchecklist_modified'", 'to': u"orm['auth.User']"}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'}),
+            'smeac': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.SMEAC']", 'on_delete': 'models.PROTECT'}),
+            'title': ('django.db.models.fields.TextField', [], {})
+        },
+        u'prescription.defaultbriefingchecklist': {
+            'Meta': {'object_name': 'DefaultBriefingChecklist'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'smeac': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.SMEAC']", 'on_delete': 'models.PROTECT'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.district': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'District'},
+            'archive_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '3'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Region']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.endorsement': {
+            'Meta': {'ordering': "[u'role']", 'object_name': 'Endorsement'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_endorsement_created'", 'to': u"orm['auth.User']"}),
+            'endorsed': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_endorsement_modified'", 'to': u"orm['auth.User']"}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.EndorsingRole']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.endorsingrole': {
+            'Meta': {'ordering': "[u'index']", 'object_name': 'EndorsingRole'},
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'disclaimer': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '320'})
+        },
+        u'prescription.forecastarea': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'ForecastArea'},
+            'districts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.District']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.fueltype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'FuelType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.fundingallocation': {
+            'Meta': {'unique_together': "((u'prescription', u'allocation'),)", 'object_name': 'FundingAllocation'},
+            'allocation': ('django.db.models.fields.PositiveSmallIntegerField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'}),
+            'proportion': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '5', 'decimal_places': '2'})
+        },
+        u'prescription.objective': {
+            'Meta': {'ordering': "[u'created']", 'object_name': 'Objective'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_objective_created'", 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_objective_modified'", 'to': u"orm['auth.User']"}),
+            'objectives': ('django.db.models.fields.TextField', [], {}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.prescription': {
+            'Meta': {'object_name': 'Prescription'},
+            'aircraft_burn': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'approval_status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'approval_status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'area': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '12', 'decimal_places': '1'}),
+            'burn_id': ('django.db.models.fields.CharField', [], {'max_length': '7'}),
+            'bushfire_act_zone': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'carried_over': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'closure_officer': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'closure'", 'null': 'True', 'on_delete': 'models.PROTECT', 'to': u"orm['auth.User']"}),
+            'contentious': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'contentious_rationale': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'contingencies_migrated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_prescription_created'", 'to': u"orm['auth.User']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'district': ('smart_selects.db_fields.ChainedForeignKey', [], {'to': u"orm['prescription.District']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'endorsement_status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'endorsement_status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'endorsing_roles': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.EndorsingRole']", 'symmetrical': 'False'}),
+            'endorsing_roles_determined': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'financial_year': ('django.db.models.fields.CharField', [], {'default': "u'2018/2019'", 'max_length': '10'}),
+            'forecast_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['prescription.ForecastArea']", 'null': 'True', 'blank': 'True'}),
+            'forest_blocks': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'fuel_types': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['prescription.FuelType']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ignition_completed_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'ignition_status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'ignition_status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'last_season': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'last_season_unknown': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_year': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'last_year_unknown': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'location': ('django.db.models.fields.CharField', [], {'max_length': "u'320'", 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_prescription_modified'", 'to': u"orm['auth.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'non_calm_tenure': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_complete': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_included': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_risks': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'perimeter': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '12', 'decimal_places': '1'}),
+            'planned_season': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '8', 'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'planned_year': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '4', 'blank': 'True'}),
+            'planning_status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'planning_status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'prescribing_officer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'priority': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'prohibited_period': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'purposes': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.Purpose']", 'symmetrical': 'False'}),
+            'rationale': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Region']", 'on_delete': 'models.PROTECT'}),
+            'regional_objectives': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['prescription.RegionalObjective']", 'null': 'True', 'blank': 'True'}),
+            'remote_sensing_priority': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '4'}),
+            'shires': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['prescription.Shire']", 'null': 'True', 'blank': 'True'}),
+            'short_code': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'tenures': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.Tenure']", 'symmetrical': 'False', 'blank': 'True'}),
+            'treatment_percentage': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'prescription.priorityjustification': {
+            'Meta': {'ordering': "[u'order']", 'unique_together': "((u'purpose', u'prescription'),)", 'object_name': 'PriorityJustification'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_priorityjustification_created'", 'to': u"orm['auth.User']"}),
+            'criteria': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_priorityjustification_modified'", 'to': u"orm['auth.User']"}),
+            'order': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'priority': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'purpose': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Purpose']", 'on_delete': 'models.PROTECT'}),
+            'rationale': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'relevant': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'prescription.purpose': {
+            'Meta': {'ordering': "[u'display_order', u'name']", 'object_name': 'Purpose'},
+            'display_order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.region': {
+            'Meta': {'object_name': 'Region'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'})
+        },
+        u'prescription.regionalobjective': {
+            'Meta': {'object_name': 'RegionalObjective'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_regionalobjective_created'", 'to': u"orm['auth.User']"}),
+            'fma_names': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'impact': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_regionalobjective_modified'", 'to': u"orm['auth.User']"}),
+            'objectives': ('django.db.models.fields.TextField', [], {}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Region']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.season': {
+            'Meta': {'ordering': "[u'-start']", 'object_name': 'Season'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_season_created'", 'to': u"orm['auth.User']"}),
+            'end': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_season_modified'", 'to': u"orm['auth.User']"}),
+            'name': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '8'}),
+            'start': ('django.db.models.fields.DateField', [], {})
+        },
+        u'prescription.shire': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "((u'name', u'district'),)", 'object_name': 'Shire'},
+            'district': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.District']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.smeac': {
+            'Meta': {'object_name': 'SMEAC'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'prescription.successcriteria': {
+            'Meta': {'ordering': "[u'created']", 'object_name': 'SuccessCriteria'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_successcriteria_created'", 'to': u"orm['auth.User']"}),
+            'criteria': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_successcriteria_modified'", 'to': u"orm['auth.User']"}),
+            'objectives': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.Objective']", 'symmetrical': 'False'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.tenure': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'Tenure'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'risk.action': {
+            'Meta': {'ordering': "[u'risk__category', u'-relevant', u'risk__name', u'pk']", 'object_name': 'Action'},
+            'context_statement': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'risk_action_created'", 'to': u"orm['auth.User']"}),
+            'day_of_burn': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_administration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_command': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'day_of_burn_completer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'day_of_burn_execution': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_include': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_mission': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_responsible': ('django.db.models.fields.CharField', [], {'default': "u'IC'", 'max_length': '200'}),
+            'day_of_burn_safety': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_situation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'details': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'risk_action_modified'", 'to': u"orm['auth.User']"}),
+            'post_burn': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'post_burn_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'post_burn_completer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'pre_burn': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'pre_burn_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'pre_burn_completer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'pre_burn_explanation': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'pre_burn_resolved': ('django.db.models.fields.CharField', [], {'default': "u'No'", 'max_length': '200', 'blank': 'True'}),
+            'relevant': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'risk': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['risk.Risk']", 'on_delete': 'models.PROTECT'}),
+            'total': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'})
+        },
+        u'risk.risk': {
+            'Meta': {'ordering': "[u'category', u'name']", 'object_name': 'Risk'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['risk.RiskCategory']", 'on_delete': 'models.PROTECT'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'risk_risk_created'", 'to': u"orm['auth.User']"}),
+            'custom': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'risk_risk_modified'", 'to': u"orm['auth.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'risk': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'})
+        },
+        u'risk.riskcategory': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'RiskCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['prescription']

--- a/pbs/prescription/migrations/0029_auto__chg_field_prescription_non_calm_tenure_complete.py
+++ b/pbs/prescription/migrations/0029_auto__chg_field_prescription_non_calm_tenure_complete.py
@@ -1,0 +1,339 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Prescription.non_calm_tenure_complete'
+        db.delete_column(u'prescription_prescription', 'non_calm_tenure_complete')
+        # Adding field 'Prescription.non_calm_tenure_complete'
+        db.add_column(u'prescription_prescription', 'non_calm_tenure_complete',
+                      self.gf('django.db.models.fields.PositiveSmallIntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Prescription.non_calm_tenure_complete2'
+        db.delete_column(u'prescription_prescription', 'non_calm_tenure_complete2')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'prescription.approval': {
+            'Meta': {'ordering': "[u'-id']", 'object_name': 'Approval'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_approval_created'", 'to': u"orm['auth.User']"}),
+            'extension_count': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'initial_valid_to': ('django.db.models.fields.DateField', [], {'default': 'datetime.datetime(2019, 11, 15, 0, 0)'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_approval_modified'", 'to': u"orm['auth.User']"}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'}),
+            'valid_to': ('django.db.models.fields.DateField', [], {})
+        },
+        u'prescription.briefingchecklist': {
+            'Meta': {'ordering': "[u'smeac__id', u'id']", 'object_name': 'BriefingChecklist'},
+            'action': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['risk.Action']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_briefingchecklist_created'", 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_briefingchecklist_modified'", 'to': u"orm['auth.User']"}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'}),
+            'smeac': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.SMEAC']", 'on_delete': 'models.PROTECT'}),
+            'title': ('django.db.models.fields.TextField', [], {})
+        },
+        u'prescription.defaultbriefingchecklist': {
+            'Meta': {'object_name': 'DefaultBriefingChecklist'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'smeac': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.SMEAC']", 'on_delete': 'models.PROTECT'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.district': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'District'},
+            'archive_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '3'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Region']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.endorsement': {
+            'Meta': {'ordering': "[u'role']", 'object_name': 'Endorsement'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_endorsement_created'", 'to': u"orm['auth.User']"}),
+            'endorsed': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_endorsement_modified'", 'to': u"orm['auth.User']"}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.EndorsingRole']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.endorsingrole': {
+            'Meta': {'ordering': "[u'index']", 'object_name': 'EndorsingRole'},
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'disclaimer': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '320'})
+        },
+        u'prescription.forecastarea': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'ForecastArea'},
+            'districts': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.District']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.fueltype': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'FuelType'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.fundingallocation': {
+            'Meta': {'unique_together': "((u'prescription', u'allocation'),)", 'object_name': 'FundingAllocation'},
+            'allocation': ('django.db.models.fields.PositiveSmallIntegerField', [], {'max_length': '64'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'}),
+            'proportion': ('django.db.models.fields.DecimalField', [], {'default': '0', 'max_digits': '5', 'decimal_places': '2'})
+        },
+        u'prescription.objective': {
+            'Meta': {'ordering': "[u'created']", 'object_name': 'Objective'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_objective_created'", 'to': u"orm['auth.User']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_objective_modified'", 'to': u"orm['auth.User']"}),
+            'objectives': ('django.db.models.fields.TextField', [], {}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.prescription': {
+            'Meta': {'object_name': 'Prescription'},
+            'aircraft_burn': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'approval_status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'approval_status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'area': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '12', 'decimal_places': '1'}),
+            'burn_id': ('django.db.models.fields.CharField', [], {'max_length': '7'}),
+            'bushfire_act_zone': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'carried_over': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'closure_officer': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'closure'", 'null': 'True', 'on_delete': 'models.PROTECT', 'to': u"orm['auth.User']"}),
+            'contentious': ('django.db.models.fields.NullBooleanField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'contentious_rationale': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'contingencies_migrated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_prescription_created'", 'to': u"orm['auth.User']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'district': ('smart_selects.db_fields.ChainedForeignKey', [], {'to': u"orm['prescription.District']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'endorsement_status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'endorsement_status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'endorsing_roles': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.EndorsingRole']", 'symmetrical': 'False'}),
+            'endorsing_roles_determined': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'financial_year': ('django.db.models.fields.CharField', [], {'default': "u'2018/2019'", 'max_length': '10'}),
+            'forecast_areas': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['prescription.ForecastArea']", 'null': 'True', 'blank': 'True'}),
+            'forest_blocks': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'fuel_types': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['prescription.FuelType']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ignition_completed_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'ignition_status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'ignition_status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'last_season': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'last_season_unknown': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_year': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'last_year_unknown': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'location': ('django.db.models.fields.CharField', [], {'max_length': "u'320'", 'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_prescription_modified'", 'to': u"orm['auth.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'non_calm_tenure': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_complete': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_complete2': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_included': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_risks': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'non_calm_tenure_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'perimeter': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '12', 'decimal_places': '1'}),
+            'planned_season': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '8', 'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'planned_year': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '4', 'blank': 'True'}),
+            'planning_status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'planning_status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'prescribing_officer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'priority': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'prohibited_period': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'purposes': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.Purpose']", 'symmetrical': 'False'}),
+            'rationale': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Region']", 'on_delete': 'models.PROTECT'}),
+            'regional_objectives': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['prescription.RegionalObjective']", 'null': 'True', 'blank': 'True'}),
+            'remote_sensing_priority': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '4'}),
+            'shires': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['prescription.Shire']", 'null': 'True', 'blank': 'True'}),
+            'short_code': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'status_modified': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'tenures': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.Tenure']", 'symmetrical': 'False', 'blank': 'True'}),
+            'treatment_percentage': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'prescription.priorityjustification': {
+            'Meta': {'ordering': "[u'order']", 'unique_together': "((u'purpose', u'prescription'),)", 'object_name': 'PriorityJustification'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_priorityjustification_created'", 'to': u"orm['auth.User']"}),
+            'criteria': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_priorityjustification_modified'", 'to': u"orm['auth.User']"}),
+            'order': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'priority': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'purpose': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Purpose']", 'on_delete': 'models.PROTECT'}),
+            'rationale': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'relevant': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'prescription.purpose': {
+            'Meta': {'ordering': "[u'display_order', u'name']", 'object_name': 'Purpose'},
+            'display_order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.region': {
+            'Meta': {'object_name': 'Region'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '64'})
+        },
+        u'prescription.regionalobjective': {
+            'Meta': {'object_name': 'RegionalObjective'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_regionalobjective_created'", 'to': u"orm['auth.User']"}),
+            'fma_names': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'impact': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_regionalobjective_modified'", 'to': u"orm['auth.User']"}),
+            'objectives': ('django.db.models.fields.TextField', [], {}),
+            'region': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Region']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.season': {
+            'Meta': {'ordering': "[u'-start']", 'object_name': 'Season'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_season_created'", 'to': u"orm['auth.User']"}),
+            'end': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_season_modified'", 'to': u"orm['auth.User']"}),
+            'name': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '8'}),
+            'start': ('django.db.models.fields.DateField', [], {})
+        },
+        u'prescription.shire': {
+            'Meta': {'ordering': "[u'name']", 'unique_together': "((u'name', u'district'),)", 'object_name': 'Shire'},
+            'district': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.District']", 'on_delete': 'models.PROTECT'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'prescription.smeac': {
+            'Meta': {'object_name': 'SMEAC'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'prescription.successcriteria': {
+            'Meta': {'ordering': "[u'created']", 'object_name': 'SuccessCriteria'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_successcriteria_created'", 'to': u"orm['auth.User']"}),
+            'criteria': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'prescription_successcriteria_modified'", 'to': u"orm['auth.User']"}),
+            'objectives': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['prescription.Objective']", 'symmetrical': 'False'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'on_delete': 'models.PROTECT'})
+        },
+        u'prescription.tenure': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'Tenure'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'risk.action': {
+            'Meta': {'ordering': "[u'risk__category', u'-relevant', u'risk__name', u'pk']", 'object_name': 'Action'},
+            'context_statement': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'risk_action_created'", 'to': u"orm['auth.User']"}),
+            'day_of_burn': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_administration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_command': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'day_of_burn_completer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'day_of_burn_execution': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_include': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_mission': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_responsible': ('django.db.models.fields.CharField', [], {'default': "u'IC'", 'max_length': '200'}),
+            'day_of_burn_safety': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'day_of_burn_situation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'details': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'risk_action_modified'", 'to': u"orm['auth.User']"}),
+            'post_burn': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'post_burn_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'post_burn_completer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'pre_burn': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'pre_burn_completed': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'pre_burn_completer': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'pre_burn_explanation': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'pre_burn_resolved': ('django.db.models.fields.CharField', [], {'default': "u'No'", 'max_length': '200', 'blank': 'True'}),
+            'relevant': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'risk': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['risk.Risk']", 'on_delete': 'models.PROTECT'}),
+            'total': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'})
+        },
+        u'risk.risk': {
+            'Meta': {'ordering': "[u'category', u'name']", 'object_name': 'Risk'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['risk.RiskCategory']", 'on_delete': 'models.PROTECT'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'risk_risk_created'", 'to': u"orm['auth.User']"}),
+            'custom': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'modifier': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'risk_risk_modified'", 'to': u"orm['auth.User']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'prescription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['prescription.Prescription']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'risk': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'})
+        },
+        u'risk.riskcategory': {
+            'Meta': {'ordering': "[u'name']", 'object_name': 'RiskCategory'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        }
+    }
+
+    complete_apps = ['prescription']

--- a/pbs/prescription/models.py
+++ b/pbs/prescription/models.py
@@ -330,6 +330,12 @@ class Prescription(Audit):
         [prev_yr4, prev_yr4],
     ]
 
+    NON_CALM_TENURE_COMPLETE_CHOICES = (
+        (1,"Yes"),
+        (2,"No"),
+        (3,"Yes and No")
+    )
+
     burn_id = models.CharField(max_length=7, verbose_name="Burn ID")
     name = models.CharField(max_length=128)
     description = models.TextField(blank=True, null=True)
@@ -461,7 +467,9 @@ class Prescription(Audit):
     non_calm_tenure = models.NullBooleanField(verbose_name="Non-CALM Act Tenure")
     non_calm_tenure_included = models.TextField(verbose_name="Non-CALM Act Tenure Included", blank=True,null=True)
     non_calm_tenure_value = models.TextField(verbose_name="Public Value in Burn", blank=True,null=True)
-    non_calm_tenure_complete = models.NullBooleanField(verbose_name="Can the burn be completed safely without the inclusion of other tenure?")
+    non_calm_tenure_complete = models.PositiveSmallIntegerField(
+        verbose_name="Can the burn be completed safely without the inclusion of other tenure?",
+        choices=NON_CALM_TENURE_COMPLETE_CHOICES, null=True,blank=True)
     non_calm_tenure_risks = models.TextField(verbose_name="Risks based issues if other tenure not included", blank=True,null=True)
 
     def __str__(self):

--- a/pbs/prescription/models.py
+++ b/pbs/prescription/models.py
@@ -450,6 +450,20 @@ class Prescription(Audit):
     contingencies_migrated = models.BooleanField(default=False, editable=False)
 #    reviewed = models.BooleanField(verbose_name="Reviewed by FMSB and DRFMS", default=False, editable=False)
 
+    #fields for  Cross Tenure/s 33(1)(f) Ministerial Declaration
+    #Non- CALM Act Tenure - Option to select 'Yes' or 'No'
+    #   If 'Yes' selected, additional mandatory fields to complete
+    #       Non-CALM Act tenure included : (free text field, option to have a drop down list of tenure types to select, but free text is likely more desirable)
+    #       Public value in burn : (free text field)
+    #       Can the burn be completed safely without the inclusion of other tenure? : (Yes or No selection)
+    #       Risk based issues if other tenure not included (free text field)
+    #   If 'No' selected, additional fields are greyed out, and left blank as not applicable
+    non_calm_tenure = models.NullBooleanField(verbose_name="Non-CALM Act Tenure")
+    non_calm_tenure_included = models.TextField(verbose_name="Non-CALM Act Tenure Included", blank=True,null=True)
+    non_calm_tenure_value = models.TextField(verbose_name="Public Value in Burn", blank=True,null=True)
+    non_calm_tenure_complete = models.NullBooleanField(verbose_name="Can the burn be completed safely without the inclusion of other tenure?")
+    non_calm_tenure_risks = models.TextField(verbose_name="Risks based issues if other tenure not included", blank=True,null=True)
+
     def __str__(self):
         return self.burn_id
 

--- a/pbs/prescription/models.py
+++ b/pbs/prescription/models.py
@@ -475,6 +475,16 @@ class Prescription(Audit):
     def __str__(self):
         return self.burn_id
 
+
+    @property
+    def non_calm_tenure_complete_name(self):
+        if self.non_calm_tenure_complete:
+            for k,v in self.NON_CALM_TENURE_COMPLETE_CHOICES:
+                if k == self.non_calm_tenure_complete:
+                    return v
+
+        return ""
+
     def purposes_list(self):
         """
         Place 'Bushfire Risk Management' at top of list/string

--- a/pbs/review/models.py
+++ b/pbs/review/models.py
@@ -718,7 +718,11 @@ class BurnProgramLink(models.Model):
 					rpb.form_name = 1 and
 					rpb.location = pb.location) as text),
 				'') AS burn_planned_distance_today, -- use planned_distance from 268a
-			  link.wkb_geometry
+			  link.wkb_geometry,
+                          coalesce((SELECT array_to_string(array_agg(pp.name),' , ')
+                                    FROM prescription_prescription_purposes ppps JOIN prescription_purpose pp ON ppps.purpose_id = pp.id
+                                    WHERE ppps.prescription_id = p.id)
+                           ,'') AS burn_purpose
 			from
 			  (((prescription_prescription p
 				 LEFT JOIN review_prescribedburn  pb ON ((p.id = pb.prescription_id)))
@@ -728,7 +732,7 @@ class BurnProgramLink(models.Model):
 				(((ack.acknow_type)::text = 'SDO_A'::text) AND (pb.form_name = 1)) OR -- approved 268a
 				((((ack.acknow_type)::text = 'SDO_B'::text) AND (pb.form_name = 2)) AND (pb.status = 1))) -- approved active 268b
 			group by
-				p.burn_id, pb.location, p.forest_blocks, burn_target_date, indicative_area,
+				p.id,p.burn_id, pb.location, p.forest_blocks, burn_target_date, indicative_area,
 				burn_target_long, burn_target_lat, burn_est_start, link.wkb_geometry,
 				burn_planned_area_today, burn_planned_distance_today, burn_target_date_raw
 			ORDER BY p.burn_id, burn_target_date_raw;

--- a/pbs/review/models.py
+++ b/pbs/review/models.py
@@ -736,4 +736,6 @@ class BurnProgramLink(models.Model):
 				burn_target_long, burn_target_lat, burn_est_start, link.wkb_geometry,
 				burn_planned_area_today, burn_planned_distance_today, burn_target_date_raw
 			ORDER BY p.burn_id, burn_target_date_raw;
-			create or replace view review_v_todaysburns as select * from review_v_dailyburns where burn_target_date_raw = current_date;''')
+			create or replace view review_v_todaysburns as select * from review_v_dailyburns where burn_target_date_raw = current_date;
+			create or replace view review_v_yesterdaysburns as select * from review_v_dailyburns where burn_target_date_raw = current_date - interval '1 day';
+                        ''')

--- a/pbs/review/models.py
+++ b/pbs/review/models.py
@@ -738,4 +738,27 @@ class BurnProgramLink(models.Model):
 			ORDER BY p.burn_id, burn_target_date_raw;
 			create or replace view review_v_todaysburns as select * from review_v_dailyburns where burn_target_date_raw = current_date;
 			create or replace view review_v_yesterdaysburns as select * from review_v_dailyburns where burn_target_date_raw = current_date - interval '1 day';
+                        CREATE  OR REPLACE  FUNCTION review_f_lastdaysburns() RETURNS setof review_v_dailyburns AS $$
+                        DECLARE
+                            last_date review_v_dailyburns.burn_target_date_raw%TYPE;
+                        BEGIN
+                            SELECT max(pb.date) INTO last_date
+                            FROM
+                                review_prescribedburn  pb LEFT JOIN review_acknowledgement ack ON pb.id = ack.burn_id
+                            WHERE (
+                                    (((ack.acknow_type)::text = 'SDO_A'::text) AND (pb.form_name = 1))
+                                    OR
+                                    ((((ack.acknow_type)::text = 'SDO_B'::text) AND (pb.form_name = 2)) AND (pb.status = 1))
+                                   )
+                                   AND (pb.date < current_date);
+                        
+                            IF last_date IS NULL THEN
+                                RETURN QUERY SELECT * FROM review_v_dailyburns WHERE false;
+                            ELSE
+                                RETURN QUERY SELECT * FROM review_v_dailyburns WHERE burn_target_date_raw = last_date;
+                            END IF;
+                        END;
+                        $$ LANGUAGE plpgsql;
+			create or replace view review_v_lastdaysburns as select * from review_f_lastdaysburns();
+
                         ''')

--- a/pbs/static/pbs/css/styles.css
+++ b/pbs/static/pbs/css/styles.css
@@ -304,3 +304,15 @@ div.navbar-fixed-bottom {
     background-color: #eeeeee;
     color: #000000;
 }
+
+
+div.error {
+    background-color: #F2DEDE;
+    padding:3px
+}
+div.freetext {
+    border-style:solid;
+    border-width:1px;
+    border-color:#ddd;
+    white-space:pre;
+}

--- a/templates/admin/epfp_daily_burn_program.html
+++ b/templates/admin/epfp_daily_burn_program.html
@@ -744,7 +744,7 @@ $(function(){
       $("#id_href").attr("href", urlStr);
     });
 
-
+    {% comment "The tab itself is already a hyperlink" %}
     $("#report-tabs").click(function() {
         var date = $("#id_date").val();
         //console.log("date " + date);
@@ -760,6 +760,7 @@ $(function(){
             },
         });
     });
+    {% endcomment %}
 
     pdf_url = function(form_name) {
         // created to allow region to be passed to admin.py
@@ -961,8 +962,8 @@ $('#_id_approval_status').multiselect();
 $('#id_approval_status').multiselect({
     includeSelectAllOption: true,
 });
-$("#id_approval_status").multiselect('selectAll', false);
-$("#id_approval_status").multiselect('refresh');
+//$("#id_approval_status").multiselect('selectAll', false);
+//$("#id_approval_status").multiselect('refresh');
 
 </script>
 {% endblock %}

--- a/templates/admin/prescription/prescription/pre_summary.html
+++ b/templates/admin/prescription/prescription/pre_summary.html
@@ -187,6 +187,22 @@
                         {% endif %}
                     </div>
                     <div>
+                        <style>
+                            #id_non_calm_tenure_complete {
+                                list-style-type:none;
+                                margin:0px;
+                                padding:0px;
+                            }
+                            #id_non_calm_tenure_complete label {
+                                display:inline;
+                            }
+                            #id_non_calm_tenure_complete li {
+                                display:inline;
+                                padding-left:10px;
+                                padding-right:10px;
+                            }
+                        </style>
+
                         <span style="font-weight:bold">Can the burn be completed safely without the inclusion of other tenure?</span> {{form.form.non_calm_tenure_complete}}
                         {% if form.form.non_calm_tenure_complete.errors %}
                             {% include "admin/prescription/prescription/display_errors.html" with errors=adminform.form.non_calm_tenure_complete.errors %}

--- a/templates/admin/prescription/prescription/pre_summary.html
+++ b/templates/admin/prescription/prescription/pre_summary.html
@@ -168,6 +168,60 @@
             <td>{{ form.form.perimeter }}</td>
         </tr>
         <tr>
+            <th>Non-CALM Act Tenure</th>
+            <td colspan="3" >
+                {{form.form.non_calm_tenure}}
+                <div id="id_non_calm_tenure_body">
+                    <div>
+                        <span style="font-weight:bold">Non-CALM Act tenure included *</span>
+                        {{form.form.non_calm_tenure_included}}
+                        {% if form.form.non_calm_tenure_included.errors %}
+                            {% include "admin/prescription/prescription/display_errors.html" with errors=adminform.form.non_calm_tenure_included.errors %}
+                        {% endif %}
+                    </div>
+                    <div>
+                        <span style="font-weight:bold">Public value in burn * </span>
+                        <br>{{form.form.non_calm_tenure_value}}
+                        {% if form.form.non_calm_tenure_value.errors %}
+                            {% include "admin/prescription/prescription/display_errors.html" with errors=adminform.form.non_calm_tenure_value.errors %}
+                        {% endif %}
+                    </div>
+                    <div>
+                        <span style="font-weight:bold">Can the burn be completed safely without the inclusion of other tenure?</span> {{form.form.non_calm_tenure_complete}}
+                        {% if form.form.non_calm_tenure_complete.errors %}
+                            {% include "admin/prescription/prescription/display_errors.html" with errors=adminform.form.non_calm_tenure_complete.errors %}
+                        {% endif %}
+                    </div>
+                    <div style="margin-top:3px">
+                        <span style="font-weight:bold">Risk based issues if other tenure not included * </span>
+                        <br>{{form.form.non_calm_tenure_risks}}
+                        {% if form.form.non_calm_tenure_risks.errors %}
+                            {% include "admin/prescription/prescription/display_errors.html" with errors=adminform.form.non_calm_tenure_risks.errors %}
+                        {% endif %}
+                    </div>
+                </div>
+                <script type="text/javascript">
+                    function check_non_calm_tenure() {
+                        if (document.getElementById("id_non_calm_tenure").value === "2") {
+                            $("#id_non_calm_tenure_body").show()
+                            $.each(["#id_non_calm_tenure_included","#id_non_calm_tenure_value","#id_non_calm_tenure_complete","#id_non_calm_tenure_risks"],function(index,id){
+                                $(id).prop('disabled',false)
+                            })
+                        } else {
+                            $("#id_non_calm_tenure_body").hide()
+                            $.each(["#id_non_calm_tenure_included","#id_non_calm_tenure_value","#id_non_calm_tenure_complete","#id_non_calm_tenure_risks"],function(index,id){
+                                $(id).prop('disabled',true)
+                            })
+                        }
+                    }
+                    $(document).ready(function(){
+                        $("#id_non_calm_tenure").change(check_non_calm_tenure);
+                        check_non_calm_tenure()
+                    })
+                </script>
+            </td>
+        </tr>
+        <tr>
             <th>Burn Tenure(s)</th>
             <td colspan="3">{{ form.form.tenures }}<input id="id_tenures" type="hidden"></input></td>
         </tr>
@@ -299,6 +353,24 @@
             <th>Perimeter/Length (kms) *</th>
             <td>{{ current.perimeter }}</td>
         </tr>
+
+        <tr>
+            <th>Non-CALM Act Tenure</th>
+            <td colspan="3" >
+                {{ current.non_calm_tenure | yesno:"Yes,No,Unknown" }}
+                {% if current.non_calm_tenure %}
+                <br><br><span style="font-weight:bold"> Non-CALM Act tenure included * </span>
+                <div class="freetext">{{current.non_calm_tenure_included}}</div>
+                <br><span style="font-weight:bold"> Public value in burn * </span>
+                <div class="freetext">{{current.non_calm_tenure_value}}</div>
+                <br><span style="font-weight:bold"> Can the burn be completed safely without the inclusion of other tenure? </span> {{current.non_calm_tenure_complete | yesno:"Yes,No" }}
+                <br><br><span style="font-weight:bold"> Risk based issues if other tenure not included * </span>
+                <div class="freetext">{{current.non_calm_tenure_risks}}</div>
+                {% endif %}
+            </td>
+        </tr>
+
+
         <tr>
             <th>Burn Tenure(s)</th>
             <td colspan="3">{{ current.tenures.all|join:", " }}</tr>

--- a/templates/admin/prescription/prescription/pre_summary.html
+++ b/templates/admin/prescription/prescription/pre_summary.html
@@ -379,7 +379,7 @@
                 <div class="freetext">{{current.non_calm_tenure_included}}</div>
                 <br><span style="font-weight:bold"> Public value in burn * </span>
                 <div class="freetext">{{current.non_calm_tenure_value}}</div>
-                <br><span style="font-weight:bold"> Can the burn be completed safely without the inclusion of other tenure? </span> {{current.non_calm_tenure_complete | yesno:"Yes,No" }}
+                <br><span style="font-weight:bold"> Can the burn be completed safely without the inclusion of other tenure? </span> {{current.non_calm_tenure_complete_name }}
                 <br><br><span style="font-weight:bold"> Risk based issues if other tenure not included * </span>
                 <div class="freetext">{{current.non_calm_tenure_risks}}</div>
                 {% endif %}


### PR DESCRIPTION
Major changes are
1. Add column 'burn_purpose' to view 'review_v_dailyburns'
2. Create view 'review_v_yesterdaysburns'
3. Cross Tenure/s 33(1)(f) Ministerial Declaration
4. Add 'SessionPersistenceMixin' to persistent filter status into session.
5. Use user's location as the default location in the filter of  'Daily Burn Program' ; save the last filter of 'Daily Burn Program' into session if it is different from default filter, and use it when return from other pages